### PR TITLE
Corrects a potential bug in the jetson EDF

### DIFF
--- a/test_cases/jetsons_election_definition.json
+++ b/test_cases/jetsons_election_definition.json
@@ -282,7 +282,7 @@
                     ],
                     "ElectionDistrictId": "county_gadget",
                     "Name": "Air Traffic Control Tax Increase",
-                    "@type": "ElectionResults.Contest"
+                    "@type": "ElectionResults.BallotMeasureContest"
                 }
             ],
             "ElectionScopeId": "county_gadget",


### PR DESCRIPTION
Hey @cwulfman, I ran your new `jetsons_election_definition.json` example through my parser, and it took an issue with this line.

My logic expects a `@type` of either `ElectionResults.CandidateContest` or `ElectionResults.BallotMeasureContest`, and requires either of those so that it can determine what type of contest it is. 

Given that it's a ballot measure contest, I was able to run it through my parser just fine if I change the above line to `ElectionResults.BallotMeasureContest`. That also tracks with the [XML version of this EDF](https://github.com/TrustTheVote-Project/NIST-1500-100-103-examples/blob/main/test_cases/jetsons_election_definition.xml#L267), which has a type of `BallotMeasureContest`

Can you let me know if my suggested change is correct?