### PR TITLE
Capitalization and stray punctuation fixed.

### DIFF
--- a/test_cases/example_2.json
+++ b/test_cases/example_2.json
@@ -178,7 +178,7 @@
             "Name": {
                 "Text": [
                     {
-                        "Content": "Spaceport precinct",
+                        "Content": "Spaceport Precinct",
                         "Language": "en",
                         "@type": "ElectionResults.LanguageString"
                     }
@@ -193,7 +193,7 @@
             "Name": {
                 "Text": [
                     {
-                        "Content": "Bedrock precinct",
+                        "Content": "Bedrock Precinct",
                         "Language": "en",
                         "@type": "ElectionResults.LanguageString"
                     }
@@ -228,7 +228,7 @@
             "Description": {
                 "Text": [
                     {
-                        "Content": "Mayor of Orbit City.",
+                        "Content": "Mayor of Orbit City",
                         "Language": "en",
                         "@type": "ElectionResults.LanguageString"
                     }
@@ -493,7 +493,7 @@
                     "BallotName": {
                         "Text": [
                             {
-                                "Content": "Sally smith",
+                                "Content": "Sally Smith",
                                 "Language": "en",
                                 "@type": "ElectionResults.LanguageString"
                             }


### PR DESCRIPTION
> I am concerned about the "\n" in some of the ballot text such as on #L1069. With a narrow device screen, forcing an enter line in a paragraph may not look good.

Anne, you had requested a way to signal paragraph breaks; the "\n" characters in the long texts are, in fact, paragraph breaks and not line breaks (at least they are intended to function that way).  Real input, especially in "long ballot measures", may well have paragraph breaks, unless we explicitly disallow them.