### PR TITLE
Reorders presidential write-in in all ordered content

### DIFF
--- a/test_cases/august_test_case.json
+++ b/test_cases/august_test_case.json
@@ -96,11 +96,6 @@
                     "ContestSelection": [
                         {
                             "@type": "ElectionResults.CandidateSelection",
-                            "@id": "recPod2L8VhwagiDl",
-                            "IsWriteIn": true
-                        },
-                        {
-                            "@type": "ElectionResults.CandidateSelection",
                             "@id": "recQK3J9IJq42hz2n",
                             "CandidateIds": [
                                 "reczKIKk81RshXkd9",
@@ -114,6 +109,11 @@
                                 "recopGzcpflkyhwdN",
                                 "recBEqMDC9w5AnKxh"
                             ]
+                        },
+                        {
+                            "@type": "ElectionResults.CandidateSelection",
+                            "@id": "recPod2L8VhwagiDl",
+                            "IsWriteIn": true
                         }
                     ]
                 },
@@ -304,9 +304,9 @@
                             "@type": "ElectionResults.OrderedContest",
                             "ContestId": "recsoZy7vYhS3lbcK",
                             "OrderedContestSelectionIds": [
-                                "recPod2L8VhwagiDl",
                                 "recQK3J9IJq42hz2n",
-                                "reccUkUdEznfODgeL"
+                                "reccUkUdEznfODgeL",
+                                "recPod2L8VhwagiDl"
                             ]
                         },
                         {
@@ -357,9 +357,9 @@
                             "@type": "ElectionResults.OrderedContest",
                             "ContestId": "recsoZy7vYhS3lbcK",
                             "OrderedContestSelectionIds": [
-                                "recPod2L8VhwagiDl",
                                 "recQK3J9IJq42hz2n",
-                                "reccUkUdEznfODgeL"
+                                "reccUkUdEznfODgeL",
+                                "recPod2L8VhwagiDl"
                             ]
                         },
                         {
@@ -407,9 +407,9 @@
                             "@type": "ElectionResults.OrderedContest",
                             "ContestId": "recsoZy7vYhS3lbcK",
                             "OrderedContestSelectionIds": [
-                                "recPod2L8VhwagiDl",
                                 "recQK3J9IJq42hz2n",
-                                "reccUkUdEznfODgeL"
+                                "reccUkUdEznfODgeL",
+                                "recPod2L8VhwagiDl"
                             ]
                         },
                         {
@@ -480,9 +480,9 @@
                             "@type": "ElectionResults.OrderedContest",
                             "ContestId": "recsoZy7vYhS3lbcK",
                             "OrderedContestSelectionIds": [
-                                "recPod2L8VhwagiDl",
                                 "recQK3J9IJq42hz2n",
-                                "reccUkUdEznfODgeL"
+                                "reccUkUdEznfODgeL",
+                                "recPod2L8VhwagiDl"
                             ]
                         },
                         {


### PR DESCRIPTION
This PR makes a few required additional changes to https://github.com/TrustTheVote-Project/NIST-1500-100-103-examples/pull/58 to allow the presidential write-in to follow the two candidate selections.